### PR TITLE
fix: support flattened SEA layout in v2.1.229+ (unblocks 2.1.229–2.1.237)

### DIFF
--- a/scripts/fetch-and-process.mjs
+++ b/scripts/fetch-and-process.mjs
@@ -1,5 +1,5 @@
 import { mkdir, rm, writeFile, readFile, stat, copyFile } from 'node:fs/promises';
-import { readdirSync } from 'node:fs';
+import { readdirSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { extractBunSEA } from './bun-sea-extract.mjs';
@@ -54,7 +54,7 @@ function fetchJson(url) {
 
 async function downloadFile(url, destPath) {
   console.log(`  ↓ ${url.split('/').slice(-2).join('/')}`);
-  execFileSync('curl', ['-sL', '--fail', '-o', destPath, url], { timeout: 600_000 });
+  execFileSync('curl', ['-sL', '--fail', '--retry', '3', '--retry-delay', '2', '--retry-all-errors', '-o', destPath, url], { timeout: 600_000 });
   return (await stat(destPath)).size;
 }
 
@@ -219,7 +219,9 @@ export async function fetchAndProcess({
     }
 
     // Verify Node.js compatibility before patching
-    const cliSrc = join(extractDir, 'src', 'entrypoints', 'cli.js');
+    // v2.1.229+: embedded layout flattened, cli.js at extract root
+    const legacyCli = join(extractDir, 'src', 'entrypoints', 'cli.js');
+    const cliSrc = existsSync(legacyCli) ? legacyCli : join(extractDir, 'cli.js');
     const { compatible, fatal } = verifyNodeCompat(cliSrc);
     if (!compatible) {
       console.error(`  ✗ ${platform} — Node.js compat check failed (${fatal} fatal)`);
@@ -231,7 +233,7 @@ export async function fetchAndProcess({
     // Patch cli.js
     const patchedPath = join(tmpDir, 'patched', `${platform}.js`);
     await mkdir(join(tmpDir, 'patched'), { recursive: true });
-    await patchFile(join(extractDir, 'src', 'entrypoints', 'cli.js'), patchedPath);
+    await patchFile(cliSrc, patchedPath);
 
     extractions[platform] = { extractDir, patchedPath, binPath };
     console.log(`  ✓ ${platform}`);


### PR DESCRIPTION
Fixes #10

## 改动

`scripts/fetch-and-process.mjs`，共 6 行：

1. **适配 v2.1.229+ 扁平化布局**：`cli.js` 从 `src/entrypoints/cli.js` 移到了提取根目录。旧路径存在则沿用（兼容 ≤2.1.228），否则回退到根目录。
2. **下载重试**：二进制下载加 `--retry 3 --retry-delay 2 --retry-all-errors`，避免 CDN 瞬时 SSL 错误（curl exit 35）拖垮整个多平台构建。

## 布局分界（二分实测 darwin-arm64 二进制）

| 版本 | 布局 |
|---|---|
| 2.1.224 / 2.1.227 / 2.1.228 | 旧（`src/entrypoints/cli.js`） |
| 2.1.229+（含 2.1.235、2.1.237） | 新（根目录 `cli.js`） |

即 2.1.225–2.1.228 用现有脚本也能构建，2.1.229 起必须本修复。

## 验证

- 2.1.235 / 2.1.237 全 9 平台 CI 构建通过（[运行记录](https://github.com/y-cruce/claude-code/actions/runs/32327081931)），P1/P3/P5–P9 全部正常应用，AST 校验通过
- darwin-arm64 本地安装后 `node cli.js --version` 正常，交互会话正常
- 2.1.223（旧布局）回归构建通过，走 legacy 分支

注：分支名沿用 fix/sea-layout-2.1.224（提 PR 时初判分界为 224，后经二分定位更正为 229）。