### PR TITLE
fix: preserve cyclic tool exports during chunk loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "extract": "node scripts/bun-sea-extract.mjs",
     "patch": "node scripts/node-compat-patch.mjs",
     "assemble": "node scripts/assemble-package.mjs",
-    "process": "node scripts/fetch-and-process.mjs"
+    "process": "node scripts/fetch-and-process.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "dependencies": {
     "acorn": "^8.16.0",

--- a/scripts/esm-chunk-patch.mjs
+++ b/scripts/esm-chunk-patch.mjs
@@ -118,10 +118,22 @@ const REQUIRE_SHIM =
   'import{readFileSync as __ccReadText}from"fs";' +
   'const __ccRawRequire=__ccMakeRequire(import.meta.url);' +
   'const __ccCyclic=(e)=>e&&e.code==="ERR_REQUIRE_CYCLE_MODULE";' +
+  // Tool exports are objects/functions that may be captured at module scope.
+  // Keep those references live so a cycle cannot permanently cache undefined.
+  'const __ccDeferredExport=(id,p)=>{const resolve=()=>{try{return __ccRawRequire(id)[p]}catch(e){if(__ccCyclic(e))return undefined;throw e}};' +
+  'return new Proxy(function(){const v=resolve();if(typeof v!=="function")throw new TypeError(`Cyclic export ${String(p)} is not callable`);return Reflect.apply(v,this,arguments)},{' +
+  'get:(_,k)=>{const v=resolve();return v===undefined?undefined:Reflect.get(v,k)},' +
+  'set:(_,k,v)=>{const t=resolve();return t!==undefined&&Reflect.set(t,k,v)},' +
+  'has:(_,k)=>{const v=resolve();return v!==undefined&&k in Object(v)},' +
+  'apply:(_,thisArg,args)=>{const v=resolve();if(typeof v!=="function")throw new TypeError(`Cyclic export ${String(p)} is not callable`);return Reflect.apply(v,thisArg,args)},' +
+  'construct:(_,args,newTarget)=>{const v=resolve();if(typeof v!=="function")throw new TypeError(`Cyclic export ${String(p)} is not constructable`);return Reflect.construct(v,args,newTarget)},' +
+  'ownKeys:()=>{const v=resolve();return v===undefined?[]:Reflect.ownKeys(Object(v))},' +
+  'getOwnPropertyDescriptor:(_,k)=>{const v=resolve();if(v===undefined)return undefined;const d=Reflect.getOwnPropertyDescriptor(Object(v),k);if(d)d.configurable=true;return d}' +
+  '})};' +
   // Retried on every access: the same id resolves normally once the cycle
   // that blocked it has finished evaluating.
   'const __ccLazyNs=(id)=>new Proxy({},{get:(_,p)=>{' +
-  'try{return __ccRawRequire(id)[p]}catch(e){if(__ccCyclic(e))return undefined;throw e}},' +
+  'try{return __ccRawRequire(id)[p]}catch(e){if(__ccCyclic(e))return /(?:Tool|TOOLS)$/.test(String(p))?__ccDeferredExport(id,p):undefined;throw e}},' +
   'has:(_,p)=>{try{return p in __ccRawRequire(id)}catch(e){if(__ccCyclic(e))return false;throw e}},' +
   'ownKeys:()=>{try{return Reflect.ownKeys(__ccRawRequire(id))}catch(e){if(__ccCyclic(e))return[];throw e}},' +
   'getOwnPropertyDescriptor:(_,p)=>{try{const d=Reflect.getOwnPropertyDescriptor(__ccRawRequire(id),p);' +

--- a/test/esm-chunk-patch.test.mjs
+++ b/test/esm-chunk-patch.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+import { patchImportMetaRequire } from '../scripts/esm-chunk-patch.mjs';
+
+test('keeps cyclic tool exports live after module evaluation', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'cc-esm-cycle-'));
+  try {
+    await writeFile(join(dir, 'a.mjs'), [
+      'import "./b.mjs";',
+      'export const ProposeSkillsTool = { name: "propose_skill" };',
+    ].join('\n'));
+
+    const b = patchImportMetaRequire([
+      'import "./a.mjs";',
+      'const seenTool = import.meta.require("./a.mjs").ProposeSkillsTool;',
+      'const seenName = import.meta.require("./a.mjs").SEARCH_TOOL_NAME;',
+      'export { seenTool, seenName };',
+    ].join('\n')).code;
+    await writeFile(join(dir, 'b.mjs'), b);
+
+    const loaded = await import(`${pathToFileURL(join(dir, 'a.mjs'))}?fixture=${Date.now()}`);
+    const cycle = await import(`${pathToFileURL(join(dir, 'b.mjs'))}?fixture=${Date.now()}`);
+    assert.equal(cycle.seenTool.name, 'propose_skill');
+    assert.equal(cycle.seenName, undefined);
+    assert.ok(loaded.ProposeSkillsTool);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('does not patch modules without import.meta.require', () => {
+  const source = 'export const value = 1;';
+  assert.deepEqual(patchImportMetaRequire(source), { code: source, patched: false });
+});


### PR DESCRIPTION
## Summary

- keep cyclic `Tool`/`TOOLS` exports live when the Node `require()` shim encounters `ERR_REQUIRE_CYCLE_MODULE`
- avoid caching a partially initialized tool export as `undefined`, which later causes `Cannot read properties of undefined (reading 'name')`
- add a Node regression fixture for deferred cyclic exports and preserve the existing primitive-export behavior

## Root cause

Starting with Claude Code 2.1.250, split ESM chunks use synchronous `require()` edges that can point back through the static import graph. The compatibility shim correctly returned `undefined` for cyclic primitive exports, but the same behavior was applied to object-valued tool exports. In 2.1.259, `ProposeSkillsTool` was captured this way and unconditionally added to the built-in tool list; tool discovery then read `.name` from the stale `undefined` value.

## Verification

- `npm test`
- `node --check scripts/esm-chunk-patch.mjs`
- `git diff --check`