### PR TITLE
fix: resolve bundled text assets relative to the require module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,14 @@ jobs:
 
           cd "$VERIFY"
           npm install --omit=optional --no-audit --no-fund
-          node cli.js --version
-          node cli.js --help | head -5
-          node cli.js mcp list
+
+          # Users launch from project directories, not the package directory.
+          # Running here catches assets accidentally resolved against cwd.
+          cd /tmp
+          node "$VERIFY/cli.js" --version
+          node "$VERIFY/cli.js" --help > "$VERIFY/help.txt"
+          head -5 "$VERIFY/help.txt"
+          node "$VERIFY/cli.js" mcp list
 
           rm -rf "$VERIFY"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - run: npm ci --ignore-scripts --no-audit --no-fund
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "extract": "node scripts/bun-sea-extract.mjs",
     "patch": "node scripts/node-compat-patch.mjs",
     "assemble": "node scripts/assemble-package.mjs",
-    "process": "node scripts/fetch-and-process.mjs"
+    "process": "node scripts/fetch-and-process.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "dependencies": {
     "acorn": "^8.16.0",

--- a/scripts/esm-chunk-patch.mjs
+++ b/scripts/esm-chunk-patch.mjs
@@ -101,7 +101,9 @@ export function rewriteBunfsPaths(code, prefix) {
 //    var a = e("/$bunfs/root/anti-patterns-c1rmzbdk.md");
 //
 //  Node would compile the markdown as JS and throw, taking the whole chunk
-//  with it, so route those extensions through readFileSync instead.
+//  with it, so route those extensions through readFileSync instead. Resolve
+//  through the module's require first: E2 emits relative paths, while fs
+//  would otherwise interpret them against the caller's working directory.
 //
 //  From 2.1.250 the bundler also loads sibling CHUNKS through require —
 //  358 sites where 2.1.246 used only dynamic import(). The static import
@@ -172,7 +174,7 @@ const REQUIRE_SHIM =
   'getOwnPropertyDescriptor:(_,p)=>{try{const d=Reflect.getOwnPropertyDescriptor(__ccRawRequire(id),p);' +
   'if(d)d.configurable=!0;return d}catch(e){if(__ccCyclic(e))return undefined;throw e}}});' +
   'const __ccRequire=Object.assign((id)=>{' +
-  `if(${TEXT_LOADER_EXT}.test(id))return __ccReadText(id,"utf8");` +
+  `if(${TEXT_LOADER_EXT}.test(id))return __ccReadText(__ccRawRequire.resolve(id),"utf8");` +
   'try{return __ccRawRequire(id)}catch(e){if(__ccCyclic(e))return __ccLazyNs(id);throw e}},' +
   '__ccRawRequire);';
 

--- a/test/esm-text-assets.test.mjs
+++ b/test/esm-text-assets.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+import { BUNFS_ROOTS } from '../scripts/bun-sea-extract.mjs';
+import { patchImportMetaRequire, rewriteBunfsPaths } from '../scripts/esm-chunk-patch.mjs';
+
+const execFileAsync = promisify(execFile);
+
+for (const bunfsRoot of BUNFS_ROOTS) {
+  for (const nested of [false, true]) {
+    test(`loads text independently of cwd (${bunfsRoot}, ${nested ? 'nested' : 'flat'})`, async (t) => {
+      const dir = await mkdtemp(join(tmpdir(), 'cc-text-assets-'));
+      t.after(() => rm(dir, { recursive: true, force: true }));
+      const packageDir = join(dir, 'package with spaces #资源');
+      const moduleDir = nested ? join(packageDir, 'chunks') : packageDir;
+      const assetDir = join(packageDir, 'assets');
+      const projectDir = join(dir, 'project');
+      await Promise.all([moduleDir, assetDir, projectDir].map((p) => mkdir(p, { recursive: true })));
+
+      const markdown = '# Packaged prompt\n你好\n';
+      const template = 'Template: {{value}}\n';
+      const data = { source: 'package' };
+      await Promise.all([
+        writeFile(join(assetDir, 'prompt.md'), markdown),
+        writeFile(join(assetDir, 'template.txt'), template),
+        writeFile(join(assetDir, 'data.json'), JSON.stringify(data)),
+        writeFile(join(moduleDir, 'runtime.mjs'), patchImportMetaRequire(
+          'export const load = import.meta.require;',
+        ).code),
+      ]);
+
+      // Match the bundle's exported require alias and the E1/E2 path rewrite.
+      // Absolute text paths and ordinary module loads must keep working too.
+      const source = [
+        'import { load } from "./runtime.mjs";',
+        'console.log(JSON.stringify([',
+        `load("${bunfsRoot}assets/prompt.md"),`,
+        `load("${bunfsRoot}assets/template.txt"),`,
+        `load("${bunfsRoot}assets/data.json"),`,
+        `load(${JSON.stringify(join(assetDir, 'prompt.md'))}),`,
+        `load.resolve("${bunfsRoot}assets/prompt.md"),`,
+        ']));',
+      ].join('\n');
+      const entry = join(moduleDir, 'entry.mjs');
+      await writeFile(entry, rewriteBunfsPaths(source, nested ? '../' : './').code);
+      const expected = [markdown, template, data, markdown, join(assetDir, 'prompt.md')];
+      async function check(cwd) {
+        const { stdout } = await execFileAsync(process.execPath, [entry], { cwd, timeout: 15000 });
+        assert.deepEqual(JSON.parse(stdout), expected, `assets read from ${cwd}`);
+      }
+
+      await check(moduleDir);
+      await check(projectDir);
+
+      // A user's same-named files must never replace the bundled prompts.
+      // Cover both ./assets and ../assets relative to the external cwd.
+      for (const shadowDir of [join(projectDir, 'assets'), join(dir, 'assets')]) {
+        await mkdir(shadowDir);
+        await writeFile(join(shadowDir, 'prompt.md'), 'Wrong cwd prompt');
+        await writeFile(join(shadowDir, 'template.txt'), 'Wrong cwd template');
+      }
+      await check(projectDir);
+    });
+  }
+}


### PR DESCRIPTION
Starting `@cometix/claude-code@2.1.261` from a project directory fails with `ENOENT` for `loopAutonomousPreamble-5hfhrxrk.md`, even though the file exists in the installed package. The runtime-path rewrite now emits relative paths, but the `.md`/`.txt` branch passes them directly to `readFileSync`, which resolves against `process.cwd()`.

Resolve text paths through the module-scoped `require.resolve()` before reading them, matching the resolver used for other require targets.

- Add regression fixtures for both BunFS path forms, flat and nested module layouts, and paths containing spaces, `#`, and Unicode. Check execution from inside and outside the package, same-named files in the working directory, absolute text paths, and ordinary JSON loading.
- Run the tests on Node 24 on Windows and Ubuntu.
- Run release smoke checks outside the package directory so the original cwd-dependent behavior cannot pass unnoticed. Capture help output before printing its first lines.

Validation:

- [GitHub Actions](https://github.com/cracer4869/claude-code/actions/runs/34466440364): Node 24 regression tests pass on both Windows and Ubuntu.

- All four regression tests fail with `ENOENT` before the fix and pass afterward on Windows / Node 24.18.0.
- An isolated copy of the installed `2.1.261` package reproduces the error with `node <package>/cli.js --help` from an external directory. Replacing only its generated require shim makes the same command exit 0. The global installation was left unchanged.
- `node --check scripts/esm-chunk-patch.mjs`, `node --check test/esm-text-assets.test.mjs`, workflow YAML parsing, release verification shell syntax, and `git diff --check` pass.

The full cross-platform release build was not run locally.

